### PR TITLE
Implement Prioritised Experience Replay

### DIFF
--- a/DQN/env.py
+++ b/DQN/env.py
@@ -9,53 +9,54 @@ class Environment:
 		self.x_history = deque([-1], maxlen=60)
 		self.high_score = 0
 		self.total_reward = 0
-		self.done = False
+		self.curr_lives = 2
 
 
 	def reset(self):
 		self.x_history = deque([-1], maxlen=60)
 		self.high_score = 0
 		self.total_reward = 0
-		self.done = False
 
 		return self.env.reset()
 
 
 	def _step(self, action):
 		state, reward, terminated, truncated, info = self.env.step(action)
-		self._update_high_score(info['x_pos'])
+		self.high_score = max(self.high_socre, info['x_pos'])
 		self.x_history.append(info['x_pos'])
+
+		done = terminated or truncated or (info['life'] < self.curr_lives) or self._not_moved()
+
+		self.curr_lives = max(self.curr_lives, info['life'])
 		
-		return state, reward, terminated, truncated, info
+		return state, reward, done, info
 
 
 	def _not_moved(self):
 		return len(set(self.x_history)) <= 1
 
 
-	def _update_high_score(self, x_pos):
-		if x_pos > self.high_score:
-			self.high_score = x_pos
-
-
 	def step(self, action, n=4):
 		reward_history = []
+		done = False
 
 		for _ in range(n):
 			
-			next_frame, reward, terminated, truncated, _ = self._step(action)
+			next_frame, reward, done, _ = self._step(action)
 			reward_history.append(reward)
 
-			if terminated or truncated or self._not_moved():
-				self.done = True
+			if done:
+				done = True
 				break
 
+		reward_history = np.clip(reward_history, -1, 1)
+
 		avg_reward = sum(reward_history) / len(reward_history)
-		avg_reward = np.clip(avg_reward, -1, 1)
+		self.total_reward = avg_reward
 
-		self.total_reward += avg_reward
+		if done: avg_reward = -1
 
-		return next_frame, avg_reward, self.done
+		return next_frame, avg_reward, done
 
 
 class Breakout:

--- a/DQN/env.py
+++ b/DQN/env.py
@@ -22,10 +22,10 @@ class Environment:
 
 	def _step(self, action):
 		state, reward, terminated, truncated, info = self.env.step(action)
-		self.high_score = max(self.high_socre, info['x_pos'])
+		self.high_score = max(self.high_score, info['x_pos'])
 		self.x_history.append(info['x_pos'])
 
-		done = terminated or truncated or (info['life'] < self.curr_lives) or self._not_moved()
+		done = terminated or truncated or self._not_moved()
 
 		self.curr_lives = max(self.curr_lives, info['life'])
 		
@@ -49,12 +49,10 @@ class Environment:
 				done = True
 				break
 
-		reward_history = np.clip(reward_history, -1, 1)
-
 		avg_reward = sum(reward_history) / len(reward_history)
-		self.total_reward = avg_reward
+		avg_reward = np.clip(avg_reward, -1, 1)
 
-		if done: avg_reward = -1
+		self.total_reward += avg_reward
 
 		return next_frame, avg_reward, done
 

--- a/DQN/replay_buffer.py
+++ b/DQN/replay_buffer.py
@@ -78,3 +78,88 @@ class ReplayBuffer:
 
 	def __len__(self):
 		return self.size
+
+
+class PrioritisedReplayBuffer:
+	def __init__(self, capacity, frame_stack, transform):
+		self.frame_stack = frame_stack
+		self.capacity = capacity + frame_stack
+		self.transform = transform
+
+		self.frames = torch.zeros((self.capacity, 84, 84), dtype=torch.float)
+		self.actions = torch.zeros(self.capacity, dtype=torch.int64)
+		self.rewards = torch.zeros(self.capacity, dtype=torch.int8)
+		self.dones = torch.ones(self.capacity, dtype=torch.bool)
+		self.priorities = torch.zeros(self.capacity, dtype=torch.float)  # p_i^alpha
+
+		self.p = 0  # pointer to next availble slot
+		self.size = 0  # number of filled slots
+		self.alpha = 0.6
+		self.beta = 0.4
+		self.epsilon = 1e-6
+
+
+	def append(self, frame, action, reward, done, priority):
+		self.frames[self.p] = self.transform(frame)
+		self.actions[self.p] = action
+		self.rewards[self.p] = reward
+		self.dones[self.p] = done
+		self.priorities[self.p] = (abs(priority) + self.epsilon) ** self.alpha
+
+		self.p = (self.p + 1) % self.capacity
+		self.size = max(self.size, self.p)
+
+
+	def add_first_frame(self, frame):
+		self.frames[self.p] = self.transform(frame)
+		self.actions[self.p] = 0
+		self.rewards[self.p] = 0
+		self.dones[self.p] = False
+		self.priorities[self.p] = 0.0
+
+		self.p = (self.p + 1) % self.capacity
+		self.size = max(self.size, self.p)
+
+
+	def stack_frames(self, index):
+		frame_stack = torch.zeros((4, 84, 84), dtype=torch.float)
+
+		for p in range(self.frame_stack-1, -1, -1):
+			frame_stack[p] = self.frames[index]
+			if self.dones[(index - 1) % self.capacity] == False:
+				index -= 1
+
+		return frame_stack
+
+
+	def current_state(self):
+		return self.stack_frames(self.p-1).unsqueeze(0)
+
+
+	def compute_probabilities(self):
+		probs = self.priorities[:self.size]
+		return probs / probs.sum()
+
+
+	def _sample_indices(self, probs, batch_size):
+		return np.random.choice(self.size, batch_size, replace=False, p=probs)
+		
+
+	def sample(self, batch_size):
+		probs = self.compute_probabilities()
+		indices = self._sample_indices(batch_size)
+
+		states = torch.stack([self.stack_frames(i - 1) for i in indices]).to('cuda')
+		actions = self.actions[indices].unsqueeze(1).to('cuda')
+		rewards = self.rewards[indices].to('cuda')
+		dones = self.dones[indices].to('cuda')
+		next_states = torch.stack([self.stack_frames(i) for i in indices]).to('cuda')
+
+		weights = (sekf.size * torch.tensor(probs[indices])).pow(-self.beta)
+		weights = weights / weights.max().to('cuda')
+
+		return states, actions, rewards, next_states, dones, weights
+
+
+	def __len__(self):
+		return self.size

--- a/DQN/train.py
+++ b/DQN/train.py
@@ -149,6 +149,7 @@ while steps <= hp.total_steps:
             "episode": episode,
             "average_loss": sum(losses) / len(losses),
             "total_reward": env.total_reward,
+            "distance": env.high_score,
             "epsilon": epsilon,
             "eval_score": eval_score,
             "steps": steps,

--- a/DQN/utils.py
+++ b/DQN/utils.py
@@ -17,9 +17,8 @@ def epsilon_greedy(policy_net, frame, epsilon):
     return action
 
 
-def create_minibatch(replay_buffer, policy_net, target_net):
-    # sample from replay buffer
-    frames, actions, rewards, next_frames, dones = replay_buffer.sample(hp.batch_size)
+def compute_targets(policy_net, target_net, transitions):
+    _, _, rewards, next_frames, dones = transitions
 
     # Double DQN logic
     with torch.no_grad():
@@ -28,11 +27,11 @@ def create_minibatch(replay_buffer, policy_net, target_net):
 
     # DQN logic
     #next_q_values = target_net(next_frames).argmax(dim=1, keepdim=True).squeeze(1)
-    
+
     # compute target
     targets = torch.where(dones, torch.tensor(-1.0, device='cuda'), rewards + hp.gamma * next_q_values)
 
-    return frames, actions, targets
+    return targets
 
 
 def evaluate(env, policy, transform, n_episodes=5):


### PR DESCRIPTION
Implements [Prioritised Experience Replay](https://arxiv.org/abs/1511.05952), and updates the super-mario-bros environment.

Additionally, removes the `create_minibatch` function and moves most of the functionality into the training loop, calling `compute_targets` to compute the targets for the transition, which allows different target computations (DQN, DDQN, etc) to take place more easily.